### PR TITLE
Handle hello event

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -35,6 +35,10 @@ impl slack::EventHandler for SlackHandler {
             }
         };
         match *event {
+            slack::Event::Hello => {
+                println!("Successfully connected to the Slack API server");
+                let _ = cli.send_message("#wurstminebot-test", "I'm back!");
+            }
             slack::Event::Message(ref message) => {
                 match *message {
                     slack::Message::Standard { ts: _, channel: _, user: _, ref text, is_starred: _, pinned_to: _, reactions: _, edited: _, attachments: _ } => {
@@ -58,9 +62,8 @@ impl slack::EventHandler for SlackHandler {
 
     fn on_close(&mut self, _: &mut slack::RtmClient) {}
 
-    fn on_connect(&mut self, cli: &mut slack::RtmClient) {
-        println!("Successfully connected to the Slack API server");
-        let _ = cli.send_message("#wurstminebot-test", "I'm back!");
+    fn on_connect(&mut self, _: &mut slack::RtmClient) {
+        println!("Connection opened");
     }
 }
 


### PR DESCRIPTION
The Slack API docs aren't very clear about this, but as I understand them, we're not supposed to be sending messages until hello is received. We now print a log message on connect _and_ on hello, and send the test message on hello instead of on connect.
