### PR TITLE
Exit after bye message is sent

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -54,6 +54,11 @@ impl slack::EventHandler for SlackHandler {
                     ref m => { println!("Message event not implemented: {:?}", m); } //TODO
                 }
             }
+            slack::Event::MessageSent { reply_to: _, ts: _, text: _ } => {
+                if self.will_exit {
+                    std::process::exit(0);
+                }
+            }
             ref e => { println!("Slack event not implemented: {:?}", e); } //TODO
         }
     }


### PR DESCRIPTION
This functionality was accidentally removed in a141db01ade210ea22c5b2c6e607c5664a40f1d5 (#3).
